### PR TITLE
feat: add support for disabling email verification

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\DataObjects\Coordinates;
 use Carbon\CarbonImmutable;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
+use Laravel\Fortify\Features;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 
 /**
@@ -27,7 +29,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
  */
 #[Fillable(['name', 'email', 'password', 'home_coordinates'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable, TwoFactorAuthenticatable;
@@ -60,5 +62,15 @@ class User extends Authenticatable
     public function hasVisited(Keep $keep): bool
     {
         return $this->visits()->where('keep_uuid', $keep->uuid)->exists();
+    }
+
+    /** {@inheritdoc} */
+    public function hasVerifiedEmail(): bool
+    {
+        if (! Features::enabled(Features::emailVerification())) {
+            return true;
+        }
+
+        return parent::hasVerifiedEmail();
     }
 }

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -148,7 +148,7 @@ return [
     'features' => [
         ...(env('REGISTRATION_DISABLED', false) ? [] : [Features::registration()]),
         Features::resetPasswords(),
-        Features::emailVerification(),
+        ...(env('EMAIL_VERIFICATION_DISABLED', false) ? [] : [Features::emailVerification()]),
         Features::twoFactorAuthentication([
             'confirm' => true,
             'confirmPassword' => true,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -73,7 +73,7 @@ parameters:
 			path: app/Livewire/Settings/Profile.php
 
 		-
-			message: '#^Instanceof between App\\Models\\User&Illuminate\\Contracts\\Auth\\MustVerifyEmail and Illuminate\\Contracts\\Auth\\MustVerifyEmail will always evaluate to true\.$#'
+			message: '#^Instanceof between App\\Models\\User and Illuminate\\Contracts\\Auth\\MustVerifyEmail will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1
 			path: app/Livewire/Settings/Profile.php

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,7 @@ use App\Livewire\Pages\Visit\Show as VisitShow;
 use Illuminate\Routing\Router;
 
 /** @var Router $router */
-$router->middleware(['auth'])->group(function (Router $router) {
+$router->middleware(['auth', 'verified'])->group(function (Router $router) {
     $router->livewire('/', KeepIndex::class)->name('keep.index');
     $router->livewire('/keeps/{keep}', KeepShow::class)->name('keep.show');
     $router->livewire('/keeps/{keep}/visit/{visit?}', VisitManage::class)->name('visit.manage');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This adds support for disabling email verification by setting `EMAIL_VERIFICATION_DISABLED=true`.

Please check the **[CONTRIBUTING](https://github.com/owenvoke/.github/blob/main/CONTRIBUTING.md)** document for more information.
