### PR TITLE
chore: add missing `wire:navigate` usage

### DIFF
--- a/resources/views/livewire/pages/keep/index.blade.php
+++ b/resources/views/livewire/pages/keep/index.blade.php
@@ -105,7 +105,7 @@
                         @endif
                     </flux:table.cell>
                     <flux:table.cell class="flex items-center gap-3">
-                        <flux:link :href="route('keep.show', $keep->uuid)">{{ $keep->name }}</flux:link>
+                        <flux:link :href="route('keep.show', $keep->uuid)" wire:navigate>{{ $keep->name }}</flux:link>
                     </flux:table.cell>
                     <flux:table.cell class="whitespace-nowrap">{{ __($keep->country->label()) }}</flux:table.cell>
                     @if($this->country?->regions())

--- a/resources/views/livewire/pages/visit/index.blade.php
+++ b/resources/views/livewire/pages/visit/index.blade.php
@@ -35,13 +35,13 @@
                 <flux:table.row :key="$visit->uuid">
                     <flux:table.cell class="w-min">
                         <flux:tooltip :content="$visit->uuid">
-                            <flux:link
-                                :href="route('visit.show', $visit->uuid)">{{ Illuminate\Support\Str::substr($visit->uuid, -12) }}</flux:link>
+                            <flux:link :href="route('visit.show', $visit->uuid)"
+                                       wire:navigate>{{ Illuminate\Support\Str::substr($visit->uuid, -12) }}</flux:link>
                         </flux:tooltip>
                     </flux:table.cell>
                     <flux:table.cell class="whitespace-nowrap">
-                        <flux:link
-                            :href="route('keep.show', $visit->keep->uuid)">{{ $visit->keep->name }}</flux:link>
+                        <flux:link :href="route('keep.show', $visit->keep->uuid)"
+                                   wire:navigate>{{ $visit->keep->name }}</flux:link>
                     </flux:table.cell>
                     <flux:table.cell class="whitespace-nowrap">
                         <time datetime="{{ $visit->visited_at->toIso8601String() }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

...

Please check the **[CONTRIBUTING](https://github.com/owenvoke/.github/blob/main/CONTRIBUTING.md)** document for more information.
